### PR TITLE
Let Appium launch xcuitrunner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN apt-get update \
 ## Install libimobiledevice
 && add-apt-repository -y ppa:quamotion/ppa \
 && apt-get install -y --no-install-recommends libplist-dev libusbmuxd-dev libusbmuxd-tools libimobiledevice-dev libimobiledevice-utils \
-## Install supervisor and wait-for-it
-&& apt-get install -y --no-install-recommends supervisor wait-for-it \
 ## For debug purposes only
 && apt-get install -y nano \
 ## Cleanup
@@ -39,14 +37,17 @@ RUN wget -nv -nc -O xcuitrunner.${xcuitrunner_version}.ubuntu.18.04-x64.deb http
 && dpkg -i xcuitrunner.${xcuitrunner_version}.ubuntu.18.04-x64.deb \
 && rm xcuitrunner.${xcuitrunner_version}.ubuntu.18.04-x64.deb
 
-# Install ios-deploy, and make sure it is on the path
+## Install ios-deploy, and make sure it is on the path
 RUN wget -nv -nc -O ios-deploy.${ios_deploy_version}.ubuntu.18.04-x64.deb http://cdn.quamotion.mobi/download/ios-deploy.${ios_deploy_version}.ubuntu.18.04-x64.deb \
 && dpkg -i ios-deploy.${ios_deploy_version}.ubuntu.18.04-x64.deb \
 && rm ios-deploy.${ios_deploy_version}.ubuntu.18.04-x64.deb \
 && ln -s /usr/share/ios-deploy/ios-deploy /usr/bin/ios-deploy
 
+## Create Xcode stubs
+COPY xcode /usr/local/xcode
+ENV DEVELOPER_DIR="/usr/local/xcode"
+ENV PATH="${DEVELOPER_DIR}:${PATH}"
+
 COPY start.sh .
-COPY appium.conf /etc/supervisor/conf.d/appium.conf
-COPY xcuitrunner.conf /etc/supervisor/conf.d/xcuitrunner.conf
 
 CMD [ "/bin/sh", "./start.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-docker: Dockerfile appium.conf start.sh xcuitrunner.conf
+docker: Dockerfile start.sh xcode/Contents/Info.plist xcode/carthage xcode/xcodebuild xcode/xcrun
 	sudo docker build . -t quamotion/appium-docker-ios:dev
 	docker image ls -q quamotion/appium-docker-ios:dev > docker_id
 
@@ -12,6 +12,7 @@ run: docker_id
 		-v /var/run/usbmuxd:/var/run/usbmuxd \
 		-v ${DEVELOPER_PROFILE_PATH}:/quamotion/quamotion.developerprofile \
 		-v ${LICENSE_PATH}:/quamotion/.license \
+		-v ${DEVELOPER_DISK_PATH}:/quamotion/devimg \
 		-e DEVELOPER_PROFILE_PASSWORD=${DEVELOPER_PROFILE_PASSWORD} \
 		--rm \
 		--name appium-docker-ios \
@@ -25,6 +26,7 @@ debug: docker_id
 		-v /var/run/usbmuxd:/var/run/usbmuxd \
 		-v ${DEVELOPER_PROFILE_PATH}:/quamotion/quamotion.developerprofile \
 		-v ${LICENSE_PATH}:/quamotion/.license \
+		-v ${DEVELOPER_DISK_PATH}:/quamotion/devimg \
 		-e DEVELOPER_PROFILE_PASSWORD=${DEVELOPER_PROFILE_PASSWORD} \
 		--rm \
 		--name appium-docker-ios \

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ docker run \
     -v /var/run/usbmuxd:/var/run/usbmuxd \
     -v ${DEVELOPER_PROFILE_PATH}:/quamotion/quamotion.developerprofile \
     -v ${LICENSE_PATH}:/quamotion/.license \
+    -v ${DEVELOPER_DISK_PATH}:/quamotion/devimg \
     -e DEVELOPER_PROFILE_PASSWORD=${DEVELOPER_PROFILE_PASSWORD} \
-    -e UDID=${UDID}
     quamotion/appium-docker-ios
 ```
 
@@ -48,7 +48,7 @@ Where:
 - `DEVELOPER_PROFILE_PATH` is the path to your iOS developer profile.
 - `DEVELOPER_PROFILE_PASSWORD` is the password for your iOS developer profile.
 - `LICENSE_PATH` is the path to your Quamotion license file.
-- `UDID` is the UDID of your device. You can omit this argument if you only have one iOS device connected to your host.
+- `DEVELOPER_DISK_PATH` is the path to the directory which contains the iOS Developer Disk images.
 
 ## Starting an Appium session
 
@@ -56,7 +56,6 @@ To start an Appium session on your iOS device:
 
 - Connect to the Appium server running at http://localhost:4723
 - Set the following capabilities:
-  * `webDriverAgentUrl` : `http://127.0.0.1:8100`
   * `platformName` : `iOS`
   * `automationName` : `XCUITest`
   * `deviceName` : `iPhone`,
@@ -69,7 +68,6 @@ For example, you could `POST http://localhost:4723/wd/hub/session` with header `
 {
   "desiredCapabilities":
   {
-    "webDriverAgentUrl":"http://127.0.0.1:8100",
     "platformName":"iOS",
     "automationName":"XCUITest",
     "deviceName":"iPhone",

--- a/appium.conf
+++ b/appium.conf
@@ -1,5 +1,0 @@
-[program:appium]
-command=/usr/bin/wait-for-it localhost:8100 -t 60 -- /usr/bin/appium
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-environment=IOSDEPLOY__LICENSEPATH=/quamotion/.license

--- a/session.json
+++ b/session.json
@@ -4,7 +4,8 @@
     "platformName":"iOS",
     "automationName":"XCUITest",
     "deviceName":"iPhone",
-    "udid":"72157b76f677f22c98864d62307fdff9d56fa62a",
+    "showXcodeLog": true,
+    "udid":"fc810465f67fd84d8fd88aa910a6ea3ff497e540",
     "bundleId":"com.apple.Preferences"
   }
 }

--- a/start.sh
+++ b/start.sh
@@ -8,38 +8,6 @@ then
     exit 1
 fi
 
-if [ -z "${UDID}" ];
-then
-    if [ $(idevice_id -l | wc -l) = "1" ];
-    then
-        export UDID=`idevice_id -l`
-    else
-        if [ $(idevice_id -l | wc -l) = "0" ];
-        then
-            echo "No iOS devices are connected to this Docker container."
-            exit 1
-        else
-            echo "More than one iOS device is connected to this Docker container. Please specify on which device"
-            echo "you want to run tests, by setting the 'UDID' environment variable to the UDID of your device."
-            echo ""
-            echo "The following devices are currently connected:"
-            idevice_id -l
-            exit 1
-        fi
-    fi
-else
-    if [ ! $(idevice_id -l | grep $UDID | wc -l) = "1" ];
-    then
-        echo "The iOS device with UDID '$UDID' is not connected to this Docker container."
-        echo ""
-        echo "The following devices are currently connected:"
-        idevice_id -l
-        exit 1
-    fi
-fi
-
-echo "Setting up Appium to run on the iOS device with UDID '${UDID}'"
-
 if [ ! -f /quamotion/quamotion.developerprofile ];
 then
     echo "You have not provided a developer profile. Please mount your developer profile"

--- a/start.sh
+++ b/start.sh
@@ -62,4 +62,4 @@ then
     exit 1
 fi
 
-supervisord -n
+appium

--- a/xcode/Contents/Info.plist
+++ b/xcode/Contents/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleShortVersionString</key>
+    <string>11.0</string>
+  </dict>
+</plist>

--- a/xcode/carthage
+++ b/xcode/carthage
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright (c) 2019 Quamotion bvba
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+echo This is a stub for Carthage. It was invoked in "$(pwd)" with arguments "$@"
+echo Copying cartfile $(pwd)/Cartfile.resolved to $(pwd)/Carthage/
+mkdir -p Carthage/
+cp Cartfile.resolved Carthage/

--- a/xcode/xcodebuild
+++ b/xcode/xcodebuild
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright (c) 2019 Quamotion bvba
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# This is a stub for xcodebuild. It is used by Appium to start the
+# WebDriverAgent on an iOS device. We forward the request to xcuitrunner.
+#
+
+echo This is a stub for xcodebuild. It was invoked in "$(pwd)" with arguments "$@"
+
+command="$1"
+
+case $command in
+    clean)
+        echo "This xcodebuild stub does not implement clean (as there is nothing to clean)"
+        echo "Silently ignoring the clean command..."
+    ;;
+    build-for-testing)
+        # Parse the device UDID. Sample invocation:
+        # xcodebuild build-for-testing
+        #   test-without-building
+        #   -project /usr/lib/node_modules/appium/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj
+        #   -scheme WebDriverAgentRunner
+        #   -destination id=some_udid
+        #   IPHONEOS_DEPLOYMENT_TARGET=12.4
+        #   GCC_TREAT_WARNINGS_AS_ERRORS=0
+        #   COMPILER_INDEX_STORE_ENABLE=NO
+        for (( i=1; i<=$#; i++))
+        do
+        case ${!i} in
+            # Find the -destination id=some_udid arguments, by finding
+            # the -destination argument first, and then accessing the
+            # next argument.
+            # Finally, take a substring of the id=some_udid argument, by
+            # removing the first three characters
+            *destination)
+                udid_index=$((i+1))
+                udid_arg=${!udid_index}
+                udid=${udid_arg:3}
+                echo "Running on device with UDID ${udid}"
+            ;;
+        esac
+        done
+
+        /usr/share/xcuitrunner/xcuitrunner \
+            run \
+            -d /quamotion/quamotion.developerprofile \
+            -p ${DEVELOPER_PROFILE_PASSWORD} \
+            -l /quamotion/.license \
+            -k /quamotion/devimg \
+            -u ${udid} \
+            -a ~
+    ;;
+    *)
+        echo "Ignoring unknown command $command"
+    ;;
+esac

--- a/xcode/xcrun
+++ b/xcode/xcrun
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Copyright (c) 2019 Quamotion bvba
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# This is a stub for xcrun. It is used by Appium to list all simulators.
+# Because there are no simulators in this Docker container, we can just
+# return an empty JSON array.
+echo "{}"

--- a/xcuitrunner.conf
+++ b/xcuitrunner.conf
@@ -1,4 +1,0 @@
-[program:xcuitrunner]
-command=/usr/share/xcuitrunner/xcuitrunner run -u %(ENV_UDID)s -d /quamotion/quamotion.developerprofile -p %(ENV_DEVELOPER_PROFILE_PASSWORD)s -l /quamotion/.license -k /quamotion/devimg -f 8100
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0


### PR DESCRIPTION
With this PR, we let Appium launch xcuitrunner, by stubbing out various Xcode-related utilities:
- A dummy implementation of `carthage` which just copies the `Cartfile.resolved`,
- A dummy implementation of `xcrun` which returns an empty list of simulators
- A dummy implementation of `xcodebuild`, where `clean` is a no-op and `build-for-testing` invokes xcuitrunner

This way:
- We are one step closer to aligning to 'native' Appium
- Users no longer need to specify a UDID parameter
- The appium-docker-ios Docker image can be used for multiple iOS devices at once