### PR TITLE
Use exec to invoke xcuitrunner, to support SIGINT/SIGTERM signal handling

### DIFF
--- a/xcode/xcodebuild
+++ b/xcode/xcodebuild
@@ -45,7 +45,10 @@ case $command in
         esac
         done
 
-        /usr/share/xcuitrunner/xcuitrunner \
+        # Make the xcuitrunner process replace this bash script. This will cause
+        # SIGTERM/SIGINT signals to be forwarded directly to xcuitrunner, which
+        # can then handle it properly.
+        exec /usr/share/xcuitrunner/xcuitrunner \
             run \
             -d ${DEVELOPER_PROFILE_PATH:-/quamotion/quamotion.developerprofile} \
             -p ${DEVELOPER_PROFILE_PASSWORD:-quamotion} \


### PR DESCRIPTION
Appium uses signals to terminate xcodebuild.
In our case, xcodebuild is a bash script. Bash will not forward these signals to child processes, so use exec to make that work.