### PR TITLE
Add arm64 Docker Images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,39 @@
+kind: pipeline
+name: linux-arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: plugins/docker
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    repo: quamotion/appium-docker-ios
+    tags: latest-arm64
+    dockerfile: Dockerfile
+
+---
+
+kind: pipeline
+name: linux-amd64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: plugins/docker
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    repo: quamotion/appium-docker-ios
+    tags: latest
+    dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,18 @@ RUN apt-get update \
 ## Install xcuitrunner
 ARG xcuitrunner_version=0.150.12
 
-RUN curl -sL http://cdn.quamotion.mobi/download/xcuitrunner.${xcuitrunner_version}.linux-x64.deb -o xcuitrunner.${xcuitrunner_version}.linux-x64.deb \
-&& dpkg -i xcuitrunner.${xcuitrunner_version}.linux-x64.deb \
-&& rm xcuitrunner.${xcuitrunner_version}.linux-x64.deb
+RUN architecture=$(uname -m) \
+&& case "$architecture" in \
+    x86_64) \
+        architecture=x64 \
+        ;; \
+    aarch64) \
+        architecture=arm64 \
+        ;; \
+esac \
+&& curl -sL http://cdn.quamotion.mobi/download/xcuitrunner.${xcuitrunner_version}.linux-${architecture}.deb -o xcuitrunner.${xcuitrunner_version}.linux-${architecture}.deb \
+&& dpkg -i xcuitrunner.${xcuitrunner_version}.linux-${architecture}.deb \
+&& rm xcuitrunner.${xcuitrunner_version}.linux-${architecture}.deb
 
 COPY start.sh .
 ENV PATH="/usr/share/xcuitrunner:${PATH}"


### PR DESCRIPTION
Add support for arm64 Docker images. This allows you to run appium-docker-ios on arm64 devices such as a Raspberry Pi 3 or 4.