### PR TITLE
Do not remove node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before-script:
 script:
 - docker build -t quamotion/appium-docker-ios:ci-${TRAVIS_BUILD_ID}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH} .
 - docker push quamotion/appium-docker-ios:ci-${TRAVIS_BUILD_ID}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH}
+- docker run quamotion/appium-docker-ios:ci-${TRAVIS_BUILD_ID}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH} node --version
+- docker run quamotion/appium-docker-ios:ci-${TRAVIS_BUILD_ID}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH} xcuitrunner --version
 
 # This deploy stage only runs once, skipping the build matrix.
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ esac \
 && dpkg -i xcuitrunner.${xcuitrunner_version}.linux-${architecture}.deb \
 && rm xcuitrunner.${xcuitrunner_version}.linux-${architecture}.deb \
 ## Cleanup
-&& apt-get remove -y wget gnupg ca-certificates \
+&& apt-get remove -y wget gnupg \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
In previous versions node was uninstalled because  it had a dependency on ca-certificates.

This PR does not longer remove ca-certificates. 
A test is added checking if node and XCUITRunner is installed.